### PR TITLE
Migrate sage-cloudpath to timsrust 0.5.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,10 +112,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "arrow-array"
-version = "53.4.0"
+name = "arrow"
+version = "57.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d45fe6d3faed0435b7313e59a02583b14c6c6339fa7729e94c32a20af319a79"
+checksum = "3bd47f2a6ddc39244bd722a27ee5da66c03369d087b9e024eafdb03e98b98ea7"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-csv",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-json",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c7bbd679c5418b8639b92be01f361d60013c4906574b578b77b63c78356594c"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8a4ab47b3f3eac60f7fd31b81e9028fda018607bcc63451aca4f2b755269862"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -123,30 +158,34 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
- "hashbrown 0.15.5",
- "num",
+ "hashbrown 0.16.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-buffer"
-version = "53.4.1"
+version = "57.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b5c681a99606f3316f2a99d9c8b6fa3aad0b1d34d8f6d7a1b471893940219d8"
+checksum = "0d18b89b4c4f4811d0858175e79541fe98e33e18db3b011708bc287b1240593f"
 dependencies = [
  "bytes",
  "half",
- "num",
+ "num-bigint",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-cast"
-version = "53.4.0"
+version = "57.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c73c6233c5b5d635a56f6010e6eb1ab9e30e94707db21cea03da317f67d84cf3"
+checksum = "722b5c41dd1d14d0a879a1bce92c6fe33f546101bb2acce57a209825edd075b3"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
+ "arrow-ord",
  "arrow-schema",
  "arrow-select",
  "atoi",
@@ -154,54 +193,137 @@ dependencies = [
  "chrono",
  "half",
  "lexical-core",
- "num",
+ "num-traits",
  "ryu",
 ]
 
 [[package]]
-name = "arrow-data"
-version = "53.4.1"
+name = "arrow-csv"
+version = "57.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd962fc3bf7f60705b25bcaa8eb3318b2545aa1d528656525ebdd6a17a6cd6fb"
+checksum = "27ddb80a4848e03b1655af496d5ac2563a779e5742fcb48f2ca2e089c9cd2197"
+dependencies = [
+ "arrow-array",
+ "arrow-cast",
+ "arrow-schema",
+ "chrono",
+ "csv",
+ "csv-core",
+ "regex",
+]
+
+[[package]]
+name = "arrow-data"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1683705c63dcf0d18972759eda48489028cbbff67af7d6bef2c6b7b74ab778a"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
  "half",
- "num",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-ipc"
-version = "53.4.0"
+version = "57.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0270dc511f11bb5fa98a25020ad51a99ca5b08d8a8dfbd17503bb9dba0388f0b"
+checksum = "8cf72d04c07229fbf4dbebe7145cac37d7cf7ec582fe705c6b92cb314af096ab"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "flatbuffers",
+]
+
+[[package]]
+name = "arrow-json"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84a905f41fedfcd7679813c89a61dc369c0f932b27aa8dcc6aa051cc781a97d"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-cast",
  "arrow-data",
  "arrow-schema",
- "flatbuffers",
+ "chrono",
+ "half",
+ "indexmap 2.13.0",
+ "itoa",
+ "lexical-core",
+ "memchr",
+ "num-traits",
+ "ryu",
+ "serde_core",
+ "serde_json",
+ "simdutf8",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "082342947d4e5a2bcccf029a0a0397e21cb3bb8421edd9571d34fb5dd2670256"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+]
+
+[[package]]
+name = "arrow-row"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a931b520a2a5e22033e01a6f2486b4cdc26f9106b759abeebc320f125e94d7"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half",
 ]
 
 [[package]]
 name = "arrow-schema"
-version = "53.4.1"
+version = "57.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35b0f9c0c3582dd55db0f136d3b44bfa0189df07adcf7dc7f2f2e74db0f52eb8"
+checksum = "e4cf0d4a6609679e03002167a61074a21d7b1ad9ea65e462b2c0a97f8a3b2bc6"
 
 [[package]]
 name = "arrow-select"
-version = "53.4.0"
+version = "57.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7471ba126d0b0aaa24b50a36bc6c25e4e74869a1fd1a5553357027a0b1c8d1f1"
+checksum = "0b320d86a9806923663bb0fd9baa65ecaba81cb0cd77ff8c1768b9716b4ef891"
 dependencies = [
  "ahash",
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
- "num",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-string"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b493e99162e5764077e7823e50ba284858d365922631c7aaefe9487b1abd02c2"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -225,7 +347,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -310,9 +432,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "7.0.0"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -321,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "4.0.3"
+version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a334ef7c9e23abf0ce748e8cd309037da93e606ad52eb372e4ce327a0dcfbdfd"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -340,6 +462,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "byteorder"
@@ -574,7 +710,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -588,7 +724,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -599,7 +735,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -610,7 +746,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -649,24 +785,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc2ab4d5a16117f9029e9a6b5e4e79f4c67f6519bc134210d4d4a04ba31f41b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -741,6 +866,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,6 +888,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "filemanager"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51a1732a31d82df73a282b3d4b2a5d06d16243a49726c5eb0cb36345a54d34e"
+dependencies = [
+ "arrow",
+ "futures",
+ "memmap2",
+ "object_store 0.11.2",
+ "parquet 57.3.1",
+ "rusqlite",
+ "serde",
+ "serde_arrow",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,11 +922,11 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flatbuffers"
-version = "24.12.23"
+version = "25.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1baf0dbf96932ec9a3038d57900329c015b0bfb7b63d904f3bc27e2b02a096"
+checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.0",
  "rustc_version",
 ]
 
@@ -776,6 +938,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -855,7 +1018,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -982,6 +1145,7 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
+ "bytemuck",
  "cfg-if",
  "crunchy",
  "num-traits",
@@ -999,9 +1163,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1020,11 +1181,11 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1266,7 +1427,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
- "displaydoc 0.2.5",
+ "displaydoc",
  "potential_utf",
  "yoke",
  "zerofrom",
@@ -1279,7 +1440,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
- "displaydoc 0.2.5",
+ "displaydoc",
  "litemap",
  "tinystr",
  "writeable",
@@ -1332,7 +1493,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
- "displaydoc 0.2.5",
+ "displaydoc",
  "icu_locale_core",
  "writeable",
  "yoke",
@@ -1430,6 +1591,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1555,9 +1725,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.30.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+checksum = "947e6816f7825b2b45027c2c32e7085da9934defa535de4a6a46b10a4d5257fa"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1565,14 +1735,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "linreg"
-version = "0.2.0"
+name = "linux-raw-sys"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c6fd2f0b9338b6d298dbcee4b4ec2a6ec2e88dc0a5f6f92d5cecd65afdf445"
-dependencies = [
- "displaydoc 0.1.7",
- "num-traits",
-]
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1603,11 +1769,32 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.5"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
+checksum = "90071f8077f8e40adfc4b7fe9cd495ce316263f19e75c2211eeff3fdf475a3d9"
 dependencies = [
  "twox-hash 2.1.2",
+]
+
+[[package]]
+name = "lzf"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c034ef7ca69017088f8522e6f74301232f13ba43b5640941abc4dce26f530521"
+
+[[package]]
+name = "marrow"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48b7541d9bd6781e25b0dfe7d638e5a8aa7950d5cdbf86f97537b5672768f7c4"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "bytemuck",
+ "half",
+ "serde",
 ]
 
 [[package]]
@@ -1629,7 +1816,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1725,7 +1912,6 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
- "num-bigint",
  "num-complex",
  "num-integer",
  "num-iter",
@@ -1784,7 +1970,6 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -1807,6 +1992,38 @@ checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
+]
+
+[[package]]
+name = "object_store"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cfccb68961a56facde1163f9319e0d15743352344e7808a11795fb99698dcaf"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "futures",
+ "httparse",
+ "humantime",
+ "hyper 1.8.1",
+ "itertools 0.13.0",
+ "md-5",
+ "parking_lot",
+ "percent-encoding",
+ "quick-xml 0.37.5",
+ "rand 0.8.5",
+ "reqwest 0.12.28",
+ "ring",
+ "rustls-pemfile 2.2.0",
+ "serde",
+ "serde_json",
+ "snafu",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
 ]
 
 [[package]]
@@ -1919,9 +2136,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "53.4.0"
+version = "57.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8957c0c95a6a1804f3e51a18f69df29be53856a8c5768cc9b6d00fcafcd2917c"
+checksum = "2e832c6aa20310fc6de7ea5a3f4e20d34fd83e3b43229d32b81ffe5c14d74692"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -1937,17 +2154,18 @@ dependencies = [
  "chrono",
  "flate2",
  "half",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "lz4_flex",
- "num",
  "num-bigint",
+ "num-integer",
+ "num-traits",
  "paste",
  "seq-macro",
+ "simdutf8",
  "snap",
  "thrift",
- "twox-hash 1.6.3",
+ "twox-hash 2.1.2",
  "zstd",
- "zstd-sys",
 ]
 
 [[package]]
@@ -2007,7 +2225,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2041,7 +2259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2061,7 +2279,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "version_check",
 ]
 
@@ -2073,6 +2291,16 @@ checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
 dependencies = [
  "memchr",
  "tokio",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -2104,7 +2332,7 @@ checksum = "a9a28b8493dd664c8b171dd944da82d933f7d456b829bfb236738e1fe06c5ba4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2304,7 +2532,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2373,7 +2601,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2475,7 +2703,7 @@ dependencies = [
  "rinja_parser",
  "rustc-hash",
  "serde",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2491,9 +2719,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.32.1"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+checksum = "a22715a5d6deef63c637207afbe68d0c72c3f8d0022d7cf9714c442d6157606b"
 dependencies = [
  "bitflags 2.11.0",
  "fallible-iterator",
@@ -2516,6 +2744,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2563,6 +2804,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2642,7 +2892,7 @@ dependencies = [
  "bytes",
  "futures",
  "log",
- "object_store",
+ "object_store 0.13.1",
  "parquet 50.0.0",
  "quick-xml 0.31.0",
  "rayon",
@@ -2777,6 +3027,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_arrow"
+version = "0.13.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038967a6dda16f5c6ca5b6e1afec9cd2361d39f0db681ca338ac5f0ccece6469"
+dependencies = [
+ "arrow-array",
+ "arrow-schema",
+ "bytemuck",
+ "chrono",
+ "half",
+ "marrow",
+ "serde",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2793,7 +3058,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2817,7 +3082,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2860,7 +3125,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2876,6 +3141,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2886,6 +3157,27 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "snafu"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "snap"
@@ -2939,17 +3231,6 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -2982,7 +3263,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3022,6 +3303,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3056,7 +3349,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3067,7 +3360,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3114,20 +3407,99 @@ dependencies = [
 
 [[package]]
 name = "timsrust"
-version = "0.4.2"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04312195f615fc45ea21087f564c4b3bfac2193690e0c0845b67f635f787f3c6"
+checksum = "74fc0b298904e9e3c8a2c7a45513da59df818e7e57b4023082fcaee0181cc32b"
+dependencies = [
+ "rayon",
+ "thiserror 2.0.18",
+ "timsrust-centroid",
+ "timsrust-core",
+ "timsrust-minitdf",
+ "timsrust-parquet-spectra",
+ "timsrust-tdf",
+ "timsrust-tsf",
+]
+
+[[package]]
+name = "timsrust-centroid"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21bff328adedf258235ed8265421cc5353500bb39d40a0a226b665b78ffd740"
+dependencies = [
+ "rayon",
+ "rustc-hash",
+ "thiserror 2.0.18",
+ "timsrust-core",
+]
+
+[[package]]
+name = "timsrust-core"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d88ed08f6806b49c909ff4f4fcd3eeeaa2b4826f58b31a5d7d971c5c8550b666"
+dependencies = [
+ "filemanager",
+ "rayon",
+ "timsrust-utils",
+]
+
+[[package]]
+name = "timsrust-minitdf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31b7acdf2f44a9d64625037a0418bfbc94c8b03fa6eaaffe11cd4296152e8ab"
 dependencies = [
  "bytemuck",
- "linreg",
- "memmap2",
- "parquet 53.4.0",
- "rayon",
- "rusqlite",
  "serde",
- "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
+ "timsrust-core",
  "zstd",
+]
+
+[[package]]
+name = "timsrust-parquet-spectra"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46287025ead2eb7ca0b5eb34d405e02b81a12dfc8e6d4e3df5dbb7840edf3cdc"
+dependencies = [
+ "serde",
+ "timsrust-core",
+]
+
+[[package]]
+name = "timsrust-tdf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1f928ebd7ea0607122888babb1709cff0250066a35f77bf70eb335c6d5ec24"
+dependencies = [
+ "lzf",
+ "rayon",
+ "serde",
+ "thiserror 2.0.18",
+ "timsrust-core",
+ "zstd",
+]
+
+[[package]]
+name = "timsrust-tsf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55b2d178b913785f94e84c0ec860e72ecd72595f57d7fa1fab61fb4a3c3e24fc"
+dependencies = [
+ "serde",
+ "thiserror 2.0.18",
+ "timsrust-core",
+ "zstd",
+]
+
+[[package]]
+name = "timsrust-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbb75fd1a3029044e94abb649482cd4badcf7982b19e972f436363cc7a4f90d"
+dependencies = [
+ "rayon",
 ]
 
 [[package]]
@@ -3145,7 +3517,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
- "displaydoc 0.2.5",
+ "displaydoc",
  "zerovec",
 ]
 
@@ -3187,7 +3559,7 @@ checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3287,7 +3659,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3489,7 +3861,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -3627,7 +3999,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3638,7 +4010,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3927,7 +4299,7 @@ dependencies = [
  "heck",
  "indexmap 2.13.0",
  "prettyplease",
- "syn 2.0.117",
+ "syn",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3943,7 +4315,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -4010,7 +4382,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -4031,7 +4403,7 @@ checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4051,7 +4423,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -4067,7 +4439,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
 dependencies = [
- "displaydoc 0.2.5",
+ "displaydoc",
  "yoke",
  "zerofrom",
 ]
@@ -4091,8 +4463,14 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5431d5661c32445236631278f27946e444ddafe4684cac70b185272d4f9c52d5"
 
 [[package]]
 name = "zmij"

--- a/crates/sage-cloudpath/Cargo.toml
+++ b/crates/sage-cloudpath/Cargo.toml
@@ -21,7 +21,7 @@ object_store = { version = "0.13", features = ["aws", "gcp", "azure"] }
 tokio = { version = "1.0", features = ["fs", "io-util", "rt", "macros"] }
 tokio-util = { version = "0.7", features = ["io"] }
 quick-xml = { version = "0.31.0", features = ["async-tokio"] }
-timsrust = { version = "0.4.2"}
+timsrust = "0.5.5"
 rayon = "1.5"
 reqwest = { version = "0.11", features = ["json", "rustls-tls"], default-features = false }
 regex = "1.6"

--- a/crates/sage-cloudpath/src/tdf.rs
+++ b/crates/sage-cloudpath/src/tdf.rs
@@ -5,9 +5,9 @@ use sage_core::{
 };
 use serde::{Deserialize, Serialize};
 use std::{cmp::Ordering, path::Path};
-use timsrust::converters::{ConvertableDomain, Scan2ImConverter, Tof2MzConverter};
-use timsrust::readers::SpectrumReader;
-use timsrust::readers::SpectrumReaderConfig as TimsrustSpectrumConfig;
+use timsrust::core::{Converter, Frame, Im, MSLevel, Mz, ScanIndex, TofIndex};
+use timsrust::{ImConverter, SpectrumReader, TimsTofPath};
+
 pub struct TdfReader;
 
 #[derive(Deserialize, Serialize, Debug, Clone, Copy)]
@@ -25,9 +25,129 @@ impl Default for BrukerMS1CentoidingConfig {
     }
 }
 
+/// Plain, serializable mirror of [`timsrust::tdf::SpectrumProcessingParams`].
+///
+/// In timsrust 0.4.2, `SpectrumReaderConfig` was a concrete, directly
+/// serializable struct. As of 0.5.x it is generic over the IM converter
+/// (`SpectrumReaderConfig<ImC>`) and the upstream `SpectrumProcessingParams`
+/// itself carries no `serde` derives. This local copy holds only the plain
+/// parameters a user can actually configure, and is converted into the
+/// upstream type at `parse()` time (see `BrukerMS2ProcessingConfig::into_timsrust`).
+#[derive(Deserialize, Serialize, Debug, Clone, Copy)]
+pub struct BrukerSpectrumProcessingParams {
+    pub smoothing_window: u32,
+    pub centroiding_window: u32,
+    pub calibration_tolerance: f64,
+    pub calibrate: bool,
+}
+
+impl Default for BrukerSpectrumProcessingParams {
+    fn default() -> Self {
+        let defaults = timsrust::tdf::SpectrumProcessingParams::default();
+        Self {
+            smoothing_window: defaults.smoothing_window,
+            centroiding_window: defaults.centroiding_window,
+            calibration_tolerance: defaults.calibration_tolerance,
+            calibrate: defaults.calibrate,
+        }
+    }
+}
+
+impl From<BrukerSpectrumProcessingParams> for timsrust::tdf::SpectrumProcessingParams {
+    fn from(p: BrukerSpectrumProcessingParams) -> Self {
+        timsrust::tdf::SpectrumProcessingParams {
+            smoothing_window: p.smoothing_window,
+            centroiding_window: p.centroiding_window,
+            calibration_tolerance: p.calibration_tolerance,
+            calibrate: p.calibrate,
+        }
+    }
+}
+
+/// Plain, serializable mirror of [`timsrust::tdf::QuadWindowExpansionStrategy`].
+///
+/// The upstream enum's `UniformMobility` variant carries an
+/// `Option<Arc<ImC>>` payload (the scan->IM converter used to sub-split
+/// windows in mobility space), which is neither serializable nor known until
+/// a dataset is opened. We drop that payload here and always pass `None` when
+/// converting back to the upstream type; timsrust fills it in automatically
+/// from the dataset's own IM converter inside
+/// `TDFSpectrumReader::new`/`FrameWindowSplittingConfiguration::finalize`.
+#[derive(Deserialize, Serialize, Debug, Clone, Copy)]
+pub enum BrukerQuadWindowExpansionStrategy {
+    None,
+    Even(usize),
+    UniformMobility(f64, f64),
+    UniformScan(usize, usize),
+}
+
+impl Default for BrukerQuadWindowExpansionStrategy {
+    fn default() -> Self {
+        Self::Even(1)
+    }
+}
+
+/// Plain, serializable mirror of [`timsrust::tdf::FrameWindowSplittingConfiguration`].
+#[derive(Deserialize, Serialize, Debug, Clone, Copy)]
+pub enum BrukerFrameSplittingConfig {
+    Quadrupole(BrukerQuadWindowExpansionStrategy),
+    Window(BrukerQuadWindowExpansionStrategy),
+}
+
+impl Default for BrukerFrameSplittingConfig {
+    fn default() -> Self {
+        Self::Quadrupole(BrukerQuadWindowExpansionStrategy::default())
+    }
+}
+
+fn convert_expansion_strategy(
+    s: BrukerQuadWindowExpansionStrategy,
+) -> timsrust::tdf::QuadWindowExpansionStrategy<ImConverter> {
+    use timsrust::tdf::QuadWindowExpansionStrategy as Q;
+    match s {
+        BrukerQuadWindowExpansionStrategy::None => Q::None,
+        BrukerQuadWindowExpansionStrategy::Even(n) => Q::Even(n),
+        BrukerQuadWindowExpansionStrategy::UniformMobility(span, step) => {
+            Q::UniformMobility((span, step), None)
+        }
+        BrukerQuadWindowExpansionStrategy::UniformScan(span, step) => Q::UniformScan((span, step)),
+    }
+}
+
+impl From<BrukerFrameSplittingConfig>
+    for timsrust::tdf::FrameWindowSplittingConfiguration<ImConverter>
+{
+    fn from(config: BrukerFrameSplittingConfig) -> Self {
+        use timsrust::tdf::FrameWindowSplittingConfiguration as F;
+        match config {
+            BrukerFrameSplittingConfig::Quadrupole(s) => {
+                F::Quadrupole(convert_expansion_strategy(s))
+            }
+            BrukerFrameSplittingConfig::Window(s) => F::Window(convert_expansion_strategy(s)),
+        }
+    }
+}
+
+/// Serializable mirror of `timsrust::tdf::SpectrumReaderConfig<ImConverter>`
+/// (the MS2/DDA spectrum reader configuration).
+#[derive(Deserialize, Serialize, Debug, Clone, Copy, Default)]
+pub struct BrukerMS2ProcessingConfig {
+    pub spectrum_processing_params: BrukerSpectrumProcessingParams,
+    pub frame_splitting_params: BrukerFrameSplittingConfig,
+}
+
+impl BrukerMS2ProcessingConfig {
+    fn into_timsrust(self) -> timsrust::tdf::SpectrumReaderConfig<ImConverter> {
+        timsrust::tdf::SpectrumReaderConfig {
+            spectrum_processing_params: self.spectrum_processing_params.into(),
+            frame_splitting_params: self.frame_splitting_params.into(),
+        }
+    }
+}
+
 #[derive(Default, Deserialize, Serialize, Debug, Clone, Copy)]
 pub struct BrukerProcessingConfig {
-    pub ms2: TimsrustSpectrumConfig,
+    pub ms2: BrukerMS2ProcessingConfig,
     pub ms1: BrukerMS1CentoidingConfig,
 }
 
@@ -39,13 +159,16 @@ impl TdfReader {
         config: BrukerProcessingConfig,
         requires_ms1: bool,
     ) -> Result<Vec<RawSpectrum>, timsrust::TimsRustError> {
-        let spectrum_reader = timsrust::readers::SpectrumReader::build()
-            .with_path(path_name.as_ref())
-            .with_config(config.ms2)
+        let path_str = path_name.as_ref().to_string_lossy().into_owned();
+        let path = TimsTofPath::new(&path_str)?;
+
+        let spectrum_reader = SpectrumReader::build()
+            .with_path(&path)
+            .with_config(config.ms2.into_timsrust())
             .finalize()?;
         let mut spectra = self.read_msn_spectra(file_id, &spectrum_reader)?;
         if requires_ms1 {
-            let ms1s = self.read_ms1_spectra(&path_name, file_id, config.ms1)?;
+            let ms1s = self.read_ms1_spectra(&path, file_id, config.ms1)?;
             spectra.extend(ms1s);
         }
 
@@ -54,20 +177,43 @@ impl TdfReader {
 
     fn read_ms1_spectra(
         &self,
-        path_name: impl AsRef<Path>,
+        path: &TimsTofPath,
         file_id: usize,
         config: BrukerMS1CentoidingConfig,
     ) -> Result<Vec<RawSpectrum>, timsrust::TimsRustError> {
         let start = std::time::Instant::now();
-        let frame_reader = timsrust::readers::FrameReader::new(path_name.as_ref())?;
-        let metadata = timsrust::readers::MetadataReader::new(path_name.as_ref())?;
-        let mz_converter = metadata.mz_converter;
-        let ims_converter = metadata.im_converter;
+        let frame_reader = timsrust::tdf::TdfFrameReader::new(path)?;
+        let mz_converter = path.mz_converter().ok_or_else(|| {
+            timsrust::tdf::MetadataReaderError::KeyNotFound(
+                "m/z calibration for this timsTOF dataset".to_string(),
+            )
+        })?;
+        let ims_converter = path.im_converter().ok_or_else(|| {
+            timsrust::tdf::MetadataReaderError::KeyNotFound(
+                "ion mobility calibration for this timsTOF dataset".to_string(),
+            )
+        })?;
         let tol_ppm = config.mz_ppm;
         let im_tol_pct = config.ims_pct;
 
-        let ms1_spectra: Vec<RawSpectrum> = frame_reader
-            .parallel_filter(|f| f.ms_level == timsrust::MSLevel::MS1)
+        let indices: Vec<usize> = frame_reader.iter_indices().collect();
+        let ms1_spectra: Vec<RawSpectrum> = indices
+            .into_par_iter()
+            // Filter on ms_level using the cheap, ion-less partial frame
+            // before paying the cost of decompressing the full frame ions
+            // (mirrors the old `FrameReader::parallel_filter` behavior).
+            .filter_map(
+                |index| match frame_reader.get_partial_frame_without_ions(index) {
+                    Ok(partial_frame) => {
+                        if partial_frame.info().ms_level() == MSLevel::MS1 {
+                            Some(frame_reader.get_frame(index))
+                        } else {
+                            None
+                        }
+                    }
+                    Err(e) => Some(Err(e)),
+                },
+            )
             .map_init(
                 || PeakBuffer::with_capacity(2 * MAX_PEAKS),
                 |buffer, frame| match frame {
@@ -79,11 +225,11 @@ impl TdfReader {
                         let (mz, (intensity, mobility)): (Vec<f32>, (Vec<f32>, Vec<f32>)) =
                             buffer.fastcentroid_frame(tol_ppm, im_tol_pct);
 
-                        let scan_start_time = frame.rt_in_seconds as f32 / 60.0;
+                        let scan_start_time = frame.info().rt_in_seconds() as f32 / 60.0;
                         let ion_injection_time = 100.0; // This is made up, in theory we can read
                                                         // if from the tdf file
                         let total_ion_current = intensity.iter().sum::<f32>();
-                        let id = frame.index.to_string();
+                        let id = frame.info().index().to_string();
 
                         let spec = RawSpectrum {
                             file_id,
@@ -124,24 +270,31 @@ impl TdfReader {
         let spectra: Vec<RawSpectrum> = (0..spectrum_reader.len())
             .into_par_iter()
             .filter_map(|index| match spectrum_reader.get(index) {
-                Ok(dda_spectrum) => match dda_spectrum.precursor {
+                Ok(dda_spectrum) => match dda_spectrum.precursor() {
                     Some(dda_precursor) => {
                         let mut precursor = Self::parse_precursor(dda_precursor);
-                        precursor.isolation_window = Option::from(Tolerance::Da(
-                            -dda_spectrum.isolation_width as f32 / 2.0,
-                            dda_spectrum.isolation_width as f32 / 2.0,
-                        ));
+                        let width = f64::from(dda_spectrum.isolation_window().width()) as f32;
+                        precursor.isolation_window =
+                            Option::from(Tolerance::Da(-width / 2.0, width / 2.0));
                         let spectrum: RawSpectrum = RawSpectrum {
                             file_id,
                             precursors: vec![precursor],
                             representation: Representation::Centroid,
-                            scan_start_time: dda_precursor.rt as f32 / 60.0,
-                            ion_injection_time: dda_precursor.rt as f32,
+                            scan_start_time: f64::from(dda_precursor.rt()) as f32 / 60.0,
+                            ion_injection_time: f64::from(dda_precursor.rt()) as f32,
                             total_ion_current: 0.0,
-                            mz: dda_spectrum.mz_values.iter().map(|&x| x as f32).collect(),
+                            mz: dda_spectrum
+                                .mz_values()
+                                .iter()
+                                .map(|&x| f64::from(x) as f32)
+                                .collect(),
                             ms_level: 2,
-                            id: dda_spectrum.index.to_string(),
-                            intensity: dda_spectrum.intensities.iter().map(|&x| x as f32).collect(),
+                            id: dda_spectrum.index().to_string(),
+                            intensity: dda_spectrum
+                                .intensities()
+                                .iter()
+                                .map(|&x| x as f32)
+                                .collect(),
                             mobility: None,
                         };
                         Some(spectrum)
@@ -154,13 +307,13 @@ impl TdfReader {
         Ok(spectra)
     }
 
-    fn parse_precursor(dda_precursor: timsrust::Precursor) -> Precursor {
+    fn parse_precursor(dda_precursor: &timsrust::core::Precursor) -> Precursor {
         let mut precursor: Precursor = Precursor::default();
-        precursor.mz = dda_precursor.mz as f32;
-        precursor.charge = dda_precursor.charge.map(|x| x as u8);
-        precursor.intensity = dda_precursor.intensity.map(|x| x as f32);
-        precursor.spectrum_ref = Option::from(dda_precursor.frame_index.to_string());
-        precursor.inverse_ion_mobility = Option::from(dda_precursor.im as f32);
+        precursor.mz = f64::from(dda_precursor.mz()) as f32;
+        precursor.charge = dda_precursor.charge().map(|x| i8::from(x) as u8);
+        precursor.intensity = dda_precursor.intensity().map(|x| x as f32);
+        precursor.spectrum_ref = Option::from(dda_precursor.frame_index().to_string());
+        precursor.inverse_ion_mobility = Option::from(f64::from(dda_precursor.im()) as f32);
         precursor
     }
 }
@@ -191,21 +344,27 @@ impl PeakBuffer {
         }
     }
 
-    fn with_frame(
+    /// Generic over the converters (rather than the concrete `MzConverter`/
+    /// `ImConverter` enums) so that a future calibrated converter can be
+    /// dropped in with no further refactor here.
+    fn with_frame<M: Converter<TofIndex, Mz>, I: Converter<ScanIndex, Im>>(
         &mut self,
-        frame: &timsrust::Frame,
-        ims_converter: &Scan2ImConverter,
-        mz_converter: &Tof2MzConverter,
+        frame: &Frame,
+        ims_converter: &I,
+        mz_converter: &M,
     ) {
-        let expect_len = frame.tof_indices.len();
+        let tof_indices = frame.ions().tof_indices();
+        let intensities = frame.ions().intensities();
+        let scan_offsets = frame.ions().scan_offsets();
+
+        let expect_len = tof_indices.len();
         self.expand_to_capacity(expect_len);
 
-        let mz_iter = frame
-            .tof_indices
+        let mz_iter = tof_indices
             .iter()
-            .map(|&x| mz_converter.convert(x as f64) as f32);
-        let intensities_iter = frame.intensities.iter().map(|&x| x as f32);
-        let imss_iter = Self::expand_mobility_iter(&frame.scan_offsets, ims_converter);
+            .map(|&x| f64::from(mz_converter.convert(x)) as f32);
+        let intensities_iter = intensities.iter().map(|&x| u32::from(x) as f32);
+        let imss_iter = Self::expand_mobility_iter(scan_offsets, ims_converter);
 
         let peak_iter = mz_iter
             .zip(intensities_iter)
@@ -263,12 +422,12 @@ impl PeakBuffer {
     /// [0,0,0,0,1]; 0 to 4 have index 0, 4 to 5 have index 1, 5 to 5 would
     /// have index 2 but its empty!
     ///
-    /// Then this index can be converted using the Scan2ImConverter.convert
+    /// Then this index can be converted using the ims_converter.convert
     ///
     /// ... This should problably be implemented and exposed in timsrust.
-    fn expand_mobility_iter<'a>(
+    fn expand_mobility_iter<'a, I: Converter<ScanIndex, Im>>(
         scan_offsets: &'a [usize],
-        ims_converter: &'a Scan2ImConverter,
+        ims_converter: &'a I,
     ) -> impl Iterator<Item = f32> + 'a {
         let ims_iter = scan_offsets
             .windows(2)
@@ -281,7 +440,10 @@ impl PeakBuffer {
                 let lo = w[0];
                 let hi = w[1];
 
-                let im = ims_converter.convert(i as f64) as f32;
+                let Ok(scan_index) = ScanIndex::try_from(i as u32) else {
+                    return None;
+                };
+                let im = f64::from(ims_converter.convert(scan_index)) as f32;
                 Some((im, lo, hi))
             })
             .flat_map(|(im, lo, hi)| (lo..hi).map(move |_| im));


### PR DESCRIPTION
Migrates `sage-cloudpath`'s Bruker TDF reader from **timsrust 0.4.2** to the published crate-split **timsrust 0.5.5**. Behavior-preserving (uncalibrated) — no calibration feature here; that's the follow-up PR that stacks on this one.

## What changes
- Dependency bump `timsrust 0.4.2` → `0.5.5` (crates.io). Ports `crates/sage-cloudpath/src/tdf.rs` to the new crate-split API: converter/reader/frame/spectrum types, typed indices (`TofIndex`/`ScanIndex`/…), and the restructured `SpectrumReaderConfig`.
- `FrameReader::parallel_filter` (removed upstream) reimplemented over `iter_indices()` + `get_frame()`, preserving the "drop bad frames, log" behavior.

## Implications / things to know
- **Fallible converters.** In 0.5.x `TimsTofPath::mz_converter()`/`im_converter()` return `Option` (0.4.2 exposed them as infallible struct fields). A missing calibration is surfaced as a per-file error — the file is skipped and logged — rather than assumed present.
- **Config JSON is preserved** via a serializable mirror (`BrukerMS2ProcessingConfig` / `BrukerFrameSplittingConfig` / `BrukerQuadWindowExpansionStrategy`) that converts to timsrust's now-generic `SpectrumReaderConfig<ImConverter>` at parse time. **One** serialized-shape divergence: the exotic `QuadWindowExpansionStrategy::UniformMobility` variant dropped its runtime converter slot, so its payload is now `(span, step)` two floats instead of `(spanstep, Option<converter>)`. Default is `Quadrupole(Even(1))` and that variant was never hand-authored with a converter, so real-world impact is ~nil.
- **`SpectrumProcessingParams.calibrate` / `calibration_tolerance` are now inert.** timsrust 0.5.x stubbed out the old empirical precursor-regression recalibration (`TDFSpectrumReader::calibrate()` is a no-op). The fields are still accepted for config back-compat but do nothing. 

## Scope
Migration only. Builds clean (`sage-cloudpath` + `sage-cli` release), no new features enabled.
